### PR TITLE
Time element breaks parsing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
   "minimum-stability": "stable",
   "require": {
     "behat/gherkin": ">=2.0.0 <5.0.0",
+    "masterminds/html5": "^2.0",
     "php": "^7.4 || ~8.0.0 || ~8.1.0",
     "ext-dom": "*",
     "ext-SimpleXML": "*",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   "minimum-stability": "stable",
   "require": {
     "behat/gherkin": ">=2.0.0 <5.0.0",
-    "masterminds/html5": "^2.0",
+    "masterminds/html5": "^2.7.5",
     "php": "^7.4 || ~8.0.0 || ~8.1.0",
     "ext-dom": "*",
     "ext-SimpleXML": "*",

--- a/src/TableParser/HTML/HTMLStringTableParser.php
+++ b/src/TableParser/HTML/HTMLStringTableParser.php
@@ -9,6 +9,7 @@ namespace Ingenerator\BehatTableAssert\TableParser\HTML;
 
 use Ingenerator\BehatTableAssert\TableNode\PaddedTableNode;
 use LibXMLError;
+use Masterminds\HTML5;
 
 /**
  * Parses an HTML string for a <table> element into a TableNode. The table must have a single row
@@ -91,18 +92,15 @@ class HTMLStringTableParser
     {
         $old_use_internal_errors = \libxml_use_internal_errors(TRUE);
         try {
-            // Parse with DOMDocument and force to utf-8 character set, otherwise (valid) unclosed
-            // HTML tags (eg <input>) cause parsing warnings. Unfortunately this means actual
-            // invalid HTML is also accepted so very few parsing errors will be detected.
-            $document = new \DOMDocument;
-            $document->loadHTML(
-                '<!DOCTYPE html><html>'
-                .'<head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>'
-                .'<body>'.\trim($html).'</body>'
-                .'</html>'
+            $html5 = new HTML5();
+            $dom = $html5->loadHTML(
+              '<!DOCTYPE html><html>'
+              .'<head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>'
+              .'<body>'.\trim($html).'</body>'
+              .'</html>'
             );
 
-            $table_elem = $document->getElementsByTagName('body')->item(0)->firstChild;
+            $table_elem = $dom->getElementsByTagName('body')->item(0)->firstChild;
             $table      = \simplexml_import_dom($table_elem);
             if ($errors = \libxml_get_errors()) {
                 $this->throwInvalidHTMLException($html, $errors);

--- a/test/TableParser/HTML/HTMLStringTableParserTest.php
+++ b/test/TableParser/HTML/HTMLStringTableParserTest.php
@@ -130,17 +130,17 @@ class HTMLStringTableParserTest extends TableParserTest
     public function provider_valid_html_tables()
     {
         return [
-            // Single header cell, no body rows
+            'Single header cell, no body rows' =>
             [
                 '<table><thead><tr><th>Header1</th></tr></thead><tbody></tbody></table>',
                 [['Header1']]
             ],
-            // Mix of th and td in header
+            'Mix of th and td in header' =>
             [
                 '<table><thead><tr><td>Header1</td><th>Header2</th></tr></thead><tbody></tbody></table>',
                 [['Header1', 'Header2']]
             ],
-            // Header and one row with mixed td and th
+            'Header and one row with mixed td and th' =>
             [
                 '<table>'.
                 '<thead><tr><td>Header1</td><th>Header2</th></tr></thead>'.
@@ -152,7 +152,7 @@ class HTMLStringTableParserTest extends TableParserTest
                     ['Cell1', 'Cell2']
                 ]
             ],
-            // Header and two rows, all td
+            'Header and two rows, all td' =>
             [
                 '<table>'.
                 '<thead><tr><td>Header1</td><td>Header2</td></tr></thead>'.
@@ -166,7 +166,7 @@ class HTMLStringTableParserTest extends TableParserTest
                     ['2.1', '2.2']
                 ]
             ],
-            // Header and one row, mixed th and td in head and body
+            'Header and one row, mixed th and td in head and body' =>
             [
                 '<table>'.
                 '<thead><tr><th>Header1</th><td>Header2</td></tr></thead>'.
@@ -178,42 +178,42 @@ class HTMLStringTableParserTest extends TableParserTest
                     ['1.1', '1.2'],
                 ]
             ],
-            // HTML escaped characters
+            'HTML escaped characters' =>
             [
                 '<table><thead><tr><th>One &amp; Two &gt; None</th></tr></thead><tbody></tbody></table>',
                 [
                     ['One & Two > None'],
                 ]
             ],
-            // Comments
+            'Comments' =>
             [
                 '<table><thead><tr><th>With <!--Comment --> inside</th></tr></thead><tbody></tbody></table>',
                 [
                     ['With inside'],
                 ]
             ],
-            // Unicode characters, unescaped
+            'Unicode characters, unescaped' =>
             [
                 '<table><thead><tr><th>It works ✓</th></tr></thead><tbody></tbody></table>',
                 [
                     ['It works ✓'],
                 ]
             ],
-            // Empty child nodes
+            'Empty child nodes' =>
             [
                 '<table><thead><tr><th>Nothing between <span></span> this</th></tr></thead><tbody></tbody></table>',
                 [
                     ['Nothing between this'],
                 ]
             ],
-            // Nested child nodes with text content
+            'Nested child nodes with text content' =>
             [
                 '<table><thead><tr><th>Nothing <span>between</span> this</th></tr></thead><tbody></tbody></table>',
                 [
                     ['Nothing between this'],
                 ]
             ],
-            // Cells containing (valid) unclosed HTML tags
+            'Cells containing (valid) unclosed HTML tags' =>
             [
                 '<table><thead><tr><th><input type="checkbox">Select</th></tr></thead><tbody></tbody></table>',
                 [

--- a/test/TableParser/HTML/HTMLStringTableParserTest.php
+++ b/test/TableParser/HTML/HTMLStringTableParserTest.php
@@ -219,7 +219,18 @@ class HTMLStringTableParserTest extends TableParserTest
                 [
                     ['Select'],
                 ]
-            ]
+            ],
+            'Table with a "time" element' => [
+                '<table>'.
+                '<thead><tr><td>Header</td><th>Date</th></tr></thead>'.
+                '<tbody>'.
+                '<tr><td>Cell1</td><time datetime="2016-08-30T12:00:00Z">30 Aug 2016</time></tr>'.
+                '</tbody></table>',
+                [
+                  ['Header', 'Date'],
+                  ['Cell1', '30 Aug 2016']
+                ]
+            ],
         ];
     }
 


### PR DESCRIPTION
Table that I need to test contains `time` element and `DOMDocument::loadHTML()` fails to parse it.

Also, I allowed myself to add a small improvement in the first commit - used comments as names for datasets. This is recommended to improve readability when tests fail.