### PR TITLE
Use PHP native html parsing (drops support for PHP < 8.4)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,22 +14,10 @@ jobs:
       fail-fast: false
       matrix:
         php_version:
-          - '8.0'
-          - '8.1'
-          - '8.2'
-          - '8.3'
           - '8.4'
         dependencies:
           - 'default'
         include:
-          - php_version: '8.0'
-            dependencies: 'lowest'
-          - php_version: '8.1'
-            dependencies: 'lowest'
-          - php_version: '8.2'
-            dependencies: 'lowest'
-          - php_version: '8.3'
-            dependencies: 'lowest'
           - php_version: '8.4'
             dependencies: 'lowest'
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## 1.3.3 / 2026-03-10
+
+* Fix handling and reporting parse errors when parsing an html table.
+
 ## 1.3.2 / 2025-05-06
 
 * Support PHP 8.4 (thanks @mharmuth)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+* Drop support for PHP < 8.4 (to allow us to use native HTML parsing)
+
 ## 1.3.3 / 2026-03-10
 
 * Fix handling and reporting parse errors when parsing an html table.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+* Use native `HTMLDocument` parsing instead of masterminds/html5
 * Drop support for PHP < 8.4 (to allow us to use native HTML parsing)
 
 ## 1.3.3 / 2026-03-10

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   "require": {
     "behat/gherkin": ">=2.0.0 <5.0.0",
     "masterminds/html5": "^2.7.5",
-    "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+    "php": ">= 8.4 < 8.5",
     "ext-dom": "*",
     "ext-SimpleXML": "*",
     "ext-libxml": "*"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
   "minimum-stability": "stable",
   "require": {
     "behat/gherkin": ">=2.0.0 <5.0.0",
-    "masterminds/html5": "^2.7.5",
     "php": ">= 8.4 < 8.5",
     "ext-dom": "*",
     "ext-SimpleXML": "*",

--- a/src/TableParser/HTML/HTMLStringTableParser.php
+++ b/src/TableParser/HTML/HTMLStringTableParser.php
@@ -9,6 +9,7 @@ namespace Ingenerator\BehatTableAssert\TableParser\HTML;
 
 use Behat\Gherkin\Node\TableNode;
 use Dom\HTMLDocument;
+use Dom\HTMLElement;
 use Ingenerator\BehatTableAssert\TableNode\PaddedTableNode;
 use LibXMLError;
 use Masterminds\HTML5;
@@ -93,31 +94,37 @@ class HTMLStringTableParser
      */
     protected function parseHTMLString($html)
     {
-        $html5 = new HTML5();
-        $dom = $html5->loadHTML(
-            '<!DOCTYPE html><html>'
-            .'<head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>'
-            .'<body>'.\trim($html).'</body>'
-            .'</html>',
-        );
+        try {
+            set_error_handler(
+                fn($errno, $errstr) => throw new \InvalidArgumentException(
+                    sprintf("Invalid HTML: %s\n\n===HTML===\n%s", $errstr, $html),
+                ),
+            );
+
+            $dom = HTMLDocument::createFromString(
+                sprintf(
+                    <<<'HTML'
+                    <!DOCTYPE html>
+                    <html>
+                    <head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>
+                    <body>%s</body>
+                    </html>
+                    HTML,
+                    trim($html),
+                ),
+            );
+        } finally {
+            restore_error_handler();
+        }
 
         $table_elem = $dom->getElementsByTagName('body')->item(0)->firstChild;
 
-        if (!$table_elem instanceof \DOMElement) {
+        if (!$table_elem instanceof HTMLElement) {
             throw new \InvalidArgumentException(
                 sprintf("Expected html root element but got %s\n\n===HTML===\n%s", get_debug_type($table_elem), $html),
             );
         }
         $table = \simplexml_import_dom($table_elem);
-        if ($errors = $html5->getErrors()) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    "Invalid HTML:\n%s\n\n===HTML===\n%s",
-                    implode("\n", array_map(fn($err) => ' - '.$err, $errors)),
-                    $html,
-                ),
-            );
-        }
 
         return $table;
     }
@@ -231,7 +238,7 @@ class HTMLStringTableParser
      */
     protected function parseCellText(\SimpleXmlElement $cell)
     {
-        $text = \trim(\preg_replace('/\s+/', ' ', \dom_import_simplexml($cell)->textContent));
+        $text = \trim(\preg_replace('/\s+/', ' ', import_simplexml($cell)->textContent));
 
         if ($prefix = (string) $cell['data-behat-table-prefix']) {
             $text = $prefix.' '.$text;

--- a/src/TableParser/HTML/HTMLStringTableParser.php
+++ b/src/TableParser/HTML/HTMLStringTableParser.php
@@ -7,9 +7,12 @@
 namespace Ingenerator\BehatTableAssert\TableParser\HTML;
 
 
+use Behat\Gherkin\Node\TableNode;
+use Dom\HTMLDocument;
 use Ingenerator\BehatTableAssert\TableNode\PaddedTableNode;
 use LibXMLError;
 use Masterminds\HTML5;
+use function Dom\import_simplexml;
 
 /**
  * Parses an HTML string for a <table> element into a TableNode. The table must have a single row
@@ -90,33 +93,37 @@ class HTMLStringTableParser
      */
     protected function parseHTMLString($html)
     {
-        $old_use_internal_errors = \libxml_use_internal_errors(TRUE);
-        try {
-            $html5 = new HTML5();
-            $dom = $html5->loadHTML(
-              '<!DOCTYPE html><html>'
-              .'<head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>'
-              .'<body>'.\trim($html).'</body>'
-              .'</html>'
+        $html5 = new HTML5();
+        $dom = $html5->loadHTML(
+            '<!DOCTYPE html><html>'
+            .'<head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>'
+            .'<body>'.\trim($html).'</body>'
+            .'</html>',
+        );
+
+        $table_elem = $dom->getElementsByTagName('body')->item(0)->firstChild;
+
+        if (!$table_elem instanceof \DOMElement) {
+            throw new \InvalidArgumentException(
+                sprintf("Expected html root element but got %s\n\n===HTML===\n%s", get_debug_type($table_elem), $html),
             );
-
-            $table_elem = $dom->getElementsByTagName('body')->item(0)->firstChild;
-            $table      = \simplexml_import_dom($table_elem);
-            if ($errors = \libxml_get_errors()) {
-                $this->throwInvalidHTMLException($html, $errors);
-            }
-        } finally {
-            \libxml_clear_errors();
-            \libxml_use_internal_errors($old_use_internal_errors);
-
+        }
+        $table = \simplexml_import_dom($table_elem);
+        if ($errors = $html5->getErrors()) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    "Invalid HTML:\n%s\n\n===HTML===\n%s",
+                    implode("\n", array_map(fn($err) => ' - '.$err, $errors)),
+                    $html,
+                ),
+            );
         }
 
         return $table;
     }
 
     /**
-     * @param string        $html
-     * @param LibXMLError[] $errors
+     * @deprecated no longer called by the library
      */
     protected function throwInvalidHTMLException($html, $errors)
     {

--- a/test/TableParser/HTML/HTMLStringTableParserTest.php
+++ b/test/TableParser/HTML/HTMLStringTableParserTest.php
@@ -224,7 +224,7 @@ class HTMLStringTableParserTest extends TableParserTest
                 '<table>'.
                 '<thead><tr><td>Header</td><th>Date</th></tr></thead>'.
                 '<tbody>'.
-                '<tr><td>Cell1</td><time datetime="2016-08-30T12:00:00Z">30 Aug 2016</time></tr>'.
+                '<tr><td>Cell1</td><td><time datetime="2016-08-30T12:00:00Z">30 Aug 2016</time></td></tr>'.
                 '</tbody></table>',
                 [
                   ['Header', 'Date'],

--- a/test/TableParser/HTML/HTMLStringTableParserTest.php
+++ b/test/TableParser/HTML/HTMLStringTableParserTest.php
@@ -35,8 +35,8 @@ class HTMLStringTableParserTest extends TableParserTest
     }
 
     /**
-     * @testWith ["random text", "Expected html root element but got DOMText"]
-     *           ["<div><17sd>illegal tag name</17sd></div>", "Invalid HTML:\n - Line 1, Col 113: Illegal tag opening"]
+     * @testWith ["random text", "Expected html root element but got Dom\\Text"]
+     *           ["<div><17sd>illegal tag name</17sd></div>", "Invalid HTML: Dom\\HTMLDocument::createFromString(): tokenizer error invalid-first-character-of-tag-name"]
      *           ["<div></div>", "Expected a <table> but got div"]
      */
     public function test_it_throws_when_parsing_html_that_is_not_a_table_or_not_valid(string $input, string $expect_msg)

--- a/test/TableParser/HTML/HTMLStringTableParserTest.php
+++ b/test/TableParser/HTML/HTMLStringTableParserTest.php
@@ -35,37 +35,16 @@ class HTMLStringTableParserTest extends TableParserTest
     }
 
     /**
-     * @testWith ["random", false]
-     *           ["random", true]
-     *           ["<div></div>", false]
-     *           ["<table><thead><tr><td>1</td></tr></thead><tbody></tbody></table>", false]
+     * @testWith ["random text", "Expected html root element but got DOMText"]
+     *           ["<div><17sd>illegal tag name</17sd></div>", "Invalid HTML:\n - Line 1, Col 113: Illegal tag opening"]
+     *           ["<div></div>", "Expected a <table> but got div"]
      */
-    public function test_it_always_restores_state_of_libxml_error_handling(
-        $html,
-        $use_errors_before
-    ) {
-        $old_setting = \libxml_use_internal_errors($use_errors_before);
-        try {
-            $this->newSubject()->parse($html);
-        } catch (\Exception $e) { /* ignore */
-        }
-        $errors_after     = \libxml_get_errors();
-        $use_errors_after = \libxml_use_internal_errors($old_setting);
-
-        $this->assertSame([], $errors_after, 'Should clear libxml errors');
-        $this->assertEquals(
-            $use_errors_before,
-            $use_errors_after,
-            'Should restore libxml_use_internal_errors'
-        );
-    }
-
-    public function test_it_throws_when_parsing_html_that_is_not_a_table()
+    public function test_it_throws_when_parsing_html_that_is_not_a_table_or_not_valid(string $input, string $expect_msg)
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Expected a <table>');
+        $this->expectExceptionMessage($expect_msg);
 
-        $this->newSubject()->parse('<div></div>');
+        $this->newSubject()->parse($input);
     }
 
     public function test_it_throws_when_parsing_table_without_thead()


### PR DESCRIPTION
Updates our supported PHP versions so that we can use the native HTML5 parser in php >= 8.4 instead of having a dependency on masterminds/html5.